### PR TITLE
Minor API tweaks

### DIFF
--- a/calladapter/api/calladapter.api
+++ b/calladapter/api/calladapter.api
@@ -1,8 +1,6 @@
 public final class at/connyduck/calladapter/networkresult/NetworkResult : java/io/Serializable {
 	public static final field Companion Lat/connyduck/calladapter/networkresult/NetworkResult$Companion;
 	public fun <init> (Ljava/lang/Object;)V
-	public final fun copy (Ljava/lang/Object;)Lat/connyduck/calladapter/networkresult/NetworkResult;
-	public static synthetic fun copy$default (Lat/connyduck/calladapter/networkresult/NetworkResult;Ljava/lang/Object;ILjava/lang/Object;)Lat/connyduck/calladapter/networkresult/NetworkResult;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun exceptionOrNull ()Ljava/lang/Throwable;
 	public final fun getOrNull ()Ljava/lang/Object;

--- a/calladapter/src/main/kotlin/at/connyduck/calladapter/networkresult/NetworkResult.kt
+++ b/calladapter/src/main/kotlin/at/connyduck/calladapter/networkresult/NetworkResult.kt
@@ -20,7 +20,7 @@ import kotlin.jvm.JvmName
  * A discriminated union that encapsulates a successful outcome with a value of type [T]
  * or a failure with an arbitrary [Throwable] exception.
  */
-public data class NetworkResult<out T>
+public class NetworkResult<out T>
     @PublishedApi
     internal constructor(
         @PublishedApi
@@ -66,6 +66,10 @@ public data class NetworkResult<out T>
                 is Failure -> value.exception
                 else -> null
             }
+
+        override fun equals(other: Any?): Boolean = other is NetworkResult<*> && value == other.value
+
+        override fun hashCode(): Int = value.hashCode()
 
         /**
          * Returns a string `Success(v)` if this instance represents [success][Result.isSuccess]

--- a/calladapter/src/main/kotlin/at/connyduck/calladapter/networkresult/NetworkResultCallAdapterFactory.kt
+++ b/calladapter/src/main/kotlin/at/connyduck/calladapter/networkresult/NetworkResultCallAdapterFactory.kt
@@ -22,7 +22,7 @@ import retrofit2.Retrofit
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 
-public class NetworkResultCallAdapterFactory internal constructor() : CallAdapter.Factory() {
+public class NetworkResultCallAdapterFactory private constructor() : CallAdapter.Factory() {
     override fun get(
         returnType: Type,
         annotations: Array<Annotation>,

--- a/calladapter/src/test/kotlin/at/connyduck/calladapter/networkresult/ApiTest.kt
+++ b/calladapter/src/test/kotlin/at/connyduck/calladapter/networkresult/ApiTest.kt
@@ -33,7 +33,7 @@ class ApiTest {
         api =
             Retrofit.Builder()
                 .baseUrl(mockWebServer.url("/"))
-                .addCallAdapterFactory(NetworkResultCallAdapterFactory())
+                .addCallAdapterFactory(NetworkResultCallAdapterFactory.create())
                 .addConverterFactory(MoshiConverterFactory.create(moshi))
                 .client(OkHttpClient())
                 .build()

--- a/calladapter/src/test/kotlin/at/connyduck/calladapter/networkresult/NetworkResultAdapterFactoryTest.kt
+++ b/calladapter/src/test/kotlin/at/connyduck/calladapter/networkresult/NetworkResultAdapterFactoryTest.kt
@@ -18,7 +18,7 @@ class NetworkResultAdapterFactoryTest {
             Types.newParameterizedType(NetworkResult::class.java, TestResponseClass::class.java)
         val callType = Types.newParameterizedType(Call::class.java, responseType)
 
-        val adapter = NetworkResultCallAdapterFactory().get(callType, arrayOf(), retrofit)
+        val adapter = NetworkResultCallAdapterFactory.create().get(callType, arrayOf(), retrofit)
 
         assertInstanceOf(NetworkResultCallAdapter::class.java, adapter)
         assertEquals(TestResponseClass::class.java, adapter?.responseType())
@@ -29,7 +29,7 @@ class NetworkResultAdapterFactoryTest {
         val responseType =
             Types.newParameterizedType(NetworkResult::class.java, TestResponseClass::class.java)
 
-        val adapter = NetworkResultCallAdapterFactory().get(responseType, arrayOf(), retrofit)
+        val adapter = NetworkResultCallAdapterFactory.create().get(responseType, arrayOf(), retrofit)
 
         assertInstanceOf(SyncNetworkResultCallAdapter::class.java, adapter)
         assertEquals(TestResponseClass::class.java, adapter?.responseType())
@@ -39,12 +39,12 @@ class NetworkResultAdapterFactoryTest {
     fun `should throw error if the type is not parameterized`() {
         assertThrows(
             IllegalStateException::class.java,
-        ) { NetworkResultCallAdapterFactory().get(NetworkResult::class.java, arrayOf(), retrofit) }
+        ) { NetworkResultCallAdapterFactory.create().get(NetworkResult::class.java, arrayOf(), retrofit) }
     }
 
     @Test
     fun `should return null if the type is not supported`() {
-        val adapter = NetworkResultCallAdapterFactory().get(TestResponseClass::class.java, arrayOf(), retrofit)
+        val adapter = NetworkResultCallAdapterFactory.create().get(TestResponseClass::class.java, arrayOf(), retrofit)
 
         assertNull(adapter)
     }


### PR DESCRIPTION
Non-public primary constructor is exposed via the generated 'copy()' method of the 'data' class.

The generated 'copy()' will change its visibility in future releases.

To suppress the warning do one of the following:
- Annotate the data class with the '@ConsistentCopyVisibility' annotation.
- Use the '-Xconsistent-data-class-copy-visibility' compiler flag.
- Annotate the data class with the '@ExposedCopyVisibility' annotation
(Discouraged, but can be used to keep binary compatibility).

To learn more, see the documentation of the '@ConsistentCopyVisibility' and '@ExposedCopyVisibility' annotations.

This will become an error in Kotlin 2.3.